### PR TITLE
Extracted Forgery builder into separate class and provided static met…

### DIFF
--- a/src/main/java/uk/co/adaptivelogic/forgery/Forgery.java
+++ b/src/main/java/uk/co/adaptivelogic/forgery/Forgery.java
@@ -15,8 +15,6 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.ServiceLoader;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -26,7 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p/>
  * <p>
  * If you need to auto create a class object then pass it to Forgery and let us provide a properly constructed
- * class for your use.  All you need to do is <pre>Forgery.get(ToForge.class)</pre>
+ * class for your use.  All you need to do is {@link #forge(Type)}
  * </p>
  */
 public class Forgery {
@@ -89,6 +87,10 @@ public class Forgery {
         }
     }
 
+    /**
+     * @deprecated Builder has been separated from Forgery to improve the api, please use {@link ForgeryBuilder} instead
+     */
+    @Deprecated
     public static class Builder {
         private ForgerRegistry registry = new GuiceForgerRegistry();
 

--- a/src/main/java/uk/co/adaptivelogic/forgery/ForgeryBuilder.java
+++ b/src/main/java/uk/co/adaptivelogic/forgery/ForgeryBuilder.java
@@ -1,0 +1,37 @@
+package uk.co.adaptivelogic.forgery;
+
+import javax.inject.Provider;
+import java.util.ServiceLoader;
+
+/**
+ * Builds the {@link Forgery} with the ability to add additional {@link Provider}'s to the current list of
+ * supported providers already registered within Forgery.
+ */
+public class ForgeryBuilder {
+
+    private ForgerRegistry registry = new GuiceForgerRegistry();
+
+    private ForgeryBuilder() {
+        for (Provider<?> forger : ServiceLoader.load(Provider.class)) {
+            registry.register(forger);
+        }
+    }
+
+    public static ForgeryBuilder forgeryBuilder() {
+        return new ForgeryBuilder();
+    }
+
+    public ForgeryBuilder withForger(Provider<?> forger) {
+        registry.register(forger);
+        return this;
+    }
+
+    public ForgeryBuilder withForger(Class<? extends Provider<?>> forgerClass) {
+        registry.register(forgerClass);
+        return this;
+    }
+
+    public Forgery build() {
+        return new Forgery(registry);
+    }
+}

--- a/src/test/java/uk/co/adaptivelogic/forgery/DefaultPojo.java
+++ b/src/test/java/uk/co/adaptivelogic/forgery/DefaultPojo.java
@@ -1,0 +1,82 @@
+package uk.co.adaptivelogic.forgery;
+
+import java.util.Date;
+
+/**
+ * Class to encapsulate the default properties that Forgery supports
+ */
+public class DefaultPojo {
+    private Date plainOldDate;
+    private Double plainOldDouble;
+    private Integer plainOldInteger;
+    private Integer plainOldLong;
+
+    private String creditCardNumber;
+    private Date dateOfBirth;
+    private String nationalInsurance;
+    private String socialSecurityNumber;
+
+    public Date getPlainOldDate() {
+        return plainOldDate;
+    }
+
+    public void setPlainOldDate(Date plainOldDate) {
+        this.plainOldDate = plainOldDate;
+    }
+
+    public Double getPlainOldDouble() {
+        return plainOldDouble;
+    }
+
+    public void setPlainOldDouble(Double plainOldDouble) {
+        this.plainOldDouble = plainOldDouble;
+    }
+
+    public Integer getPlainOldInteger() {
+        return plainOldInteger;
+    }
+
+    public void setPlainOldInteger(Integer plainOldInteger) {
+        this.plainOldInteger = plainOldInteger;
+    }
+
+    public Integer getPlainOldLong() {
+        return plainOldLong;
+    }
+
+    public void setPlainOldLong(Integer plainOldLong) {
+        this.plainOldLong = plainOldLong;
+    }
+
+    public String getCreditCardNumber() {
+        return creditCardNumber;
+    }
+
+    public void setCreditCardNumber(String creditCardNumber) {
+        this.creditCardNumber = creditCardNumber;
+    }
+
+    public Date getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(Date dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getNationalInsurance() {
+        return nationalInsurance;
+    }
+
+    public void setNationalInsurance(String nationalInsurance) {
+        this.nationalInsurance = nationalInsurance;
+    }
+
+    public String getSocialSecurityNumber() {
+        return socialSecurityNumber;
+    }
+
+    public void setSocialSecurityNumber(String socialSecurityNumber) {
+        this.socialSecurityNumber = socialSecurityNumber;
+    }
+}

--- a/src/test/java/uk/co/adaptivelogic/forgery/ForgeryBuilderTest.java
+++ b/src/test/java/uk/co/adaptivelogic/forgery/ForgeryBuilderTest.java
@@ -1,0 +1,84 @@
+package uk.co.adaptivelogic.forgery;
+
+import com.google.inject.Provider;
+import org.junit.Test;
+import uk.co.adaptivelogic.forgery.domain.Employee;
+import uk.co.adaptivelogic.forgery.domain.Manager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static uk.co.adaptivelogic.forgery.ForgeryBuilder.forgeryBuilder;
+
+public class ForgeryBuilderTest {
+
+    @Test
+    public void shouldProvideForgeryForSupportedProvidersWithoutTheNeedForAddingProviders() {
+        // When
+        DefaultPojo defaultPojo = forgeryBuilder().build().forge(DefaultPojo.class);
+
+        // Then
+        assertThat(defaultPojo.getPlainOldDate(), is(notNullValue()));
+        assertThat(defaultPojo.getPlainOldDouble(), is(notNullValue()));
+        assertThat(defaultPojo.getPlainOldInteger(), is(notNullValue()));
+        assertThat(defaultPojo.getPlainOldLong(), is(notNullValue()));
+
+        assertThat(defaultPojo.getCreditCardNumber(), is(notNullValue()));
+        assertThat(defaultPojo.getDateOfBirth(), is(notNullValue()));
+        assertThat(defaultPojo.getNationalInsurance(), is(notNullValue()));
+        assertThat(defaultPojo.getSocialSecurityNumber(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldWorkMultipleTimesAndProvideDifferentForgeries() {
+        // When
+        Employee employee = forgeryBuilder().build().forge(Employee.class);
+        Employee employee2 = forgeryBuilder().build().forge(Employee.class);
+
+        // Then
+        assertThat(employee, is(not(employee2)));
+    }
+
+    @Test
+    public void shouldAllowUsersToSupplyTheirOwnForgers() {
+        // Given
+        Forgery forgery = forgeryBuilder()
+                .withForger(new FirstNameStringForger())
+                .withForger(new LastNameStringForger())
+                .build();
+
+        // When
+        Employee employee = forgery.forge(Employee.class);
+
+        // Then
+        assertThat(employee.getFirstName(), is("John"));
+        assertThat(employee.getLastName(), is("Smith"));
+    }
+
+    @Test
+    public void shouldAllowForgingOfParameterizedTypes() {
+        // Given
+        Forgery forgery = forgeryBuilder()
+                .withForger(new FirstNameStringForger())
+                .withForger(new LastNameStringForger())
+                .withForger(new Provider<List<Employee>>() {
+                    public List<Employee> get() {
+                        return new ArrayList<Employee>();
+                    }
+                }).build();
+
+        // When
+        Manager manager = forgery.forge(Manager.class);
+
+        // Then
+        for (Employee employee : manager.getSubordinates()) {
+            assertThat(employee.getFirstName(), is(notNullValue()));
+            assertThat(employee.getLastName(), is(notNullValue()));
+        }
+    }
+
+}

--- a/src/test/java/uk/co/adaptivelogic/forgery/ForgeryTest.java
+++ b/src/test/java/uk/co/adaptivelogic/forgery/ForgeryTest.java
@@ -1,20 +1,14 @@
 package uk.co.adaptivelogic.forgery;
 
 import com.google.common.base.Optional;
-import com.google.common.reflect.TypeToken;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import uk.co.adaptivelogic.forgery.domain.Employee;
-import uk.co.adaptivelogic.forgery.domain.Manager;
 
 import javax.inject.Provider;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.rules.ExpectedException.none;
 
 /**
@@ -26,40 +20,6 @@ public class ForgeryTest {
     public ExpectedException expectedException = none();
 
     @Test
-    public void shouldCreateInstanceOfClass() {
-        // When
-        String string = new Forgery.Builder().build().forge(String.class);
-
-        // Then
-        assertThat(string, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldCreateInstanceOfClassWithProperties() {
-        // When
-        Employee person = new Forgery.Builder().build().forge(Employee.class);
-
-        // Then
-        assertThat(person, is(notNullValue()));
-        assertThat(person.getFirstName(), is(notNullValue()));
-        assertThat(person.getLastName(), is(notNullValue()));
-    }
-
-    @Test
-    public void shouldUseForgerForForgingClass() {
-        Provider<String> forger = new Provider<String>() {
-            public String get() {
-                return "Example";
-            }
-        };
-        // When
-        String string = new Forgery.Builder().withForger(forger).build().forge(String.class);
-
-        // Then
-        assertThat(string, is("Example"));
-    }
-
-    @Test
     public void shouldThrowNullPointerWhenPassingNullObjectWithUsefulMessageForUser() {
         // Then
         expectedException.expect(NullPointerException.class);
@@ -68,74 +28,6 @@ public class ForgeryTest {
         // When
         Forgery forgery = new Forgery(new FakeForgerRegistry());
         forgery.forge(null);
-    }
-
-    @Test
-    public void shouldCreateInstanceOfClassUsingLoadedForger() {
-        // When
-        Long actual = new Forgery.Builder().build().forge(Long.class);
-
-        // Then
-        assertThat(actual, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldFillPropertyWithRelevantData() {
-        // When
-        Employee employee = new Forgery.Builder()
-                .withForger(new FirstNameStringForger())
-                .withForger(new LastNameStringForger())
-                .build().forge(Employee.class);
-
-        // Then
-        assertThat(employee.getFirstName(), is("John"));
-        assertThat(employee.getLastName(), is("Smith"));
-    }
-
-    @Test
-    public void shouldCreateClassWithParameterizedProperty() {
-        // When
-        Manager manager = new Forgery.Builder()
-                .withForger(new FirstNameStringForger())
-                .withForger(new LastNameStringForger())
-                .withForger(new Provider<List<Employee>>() {
-                    public List<Employee> get() {
-                        return new ArrayList<Employee>();
-                    }
-                })
-                .build().forge(Manager.class);
-
-        // Then
-        assertThat(manager.getFirstName(), is("John"));
-        assertThat(manager.getLastName(), is("Smith"));
-    }
-
-    @Test
-    public void shouldCreateParameterizedType() {
-        // When
-        List<Employee> employees = new Forgery.Builder()
-                .withForger(new Provider<List<Employee>>() {
-                    public List<Employee> get() {
-                        return new ArrayList<Employee>();
-                    }
-                })
-                .build().forge(new TypeToken<List<Employee>>() {
-                }.getType());
-
-        // Then
-        assertThat(employees, is(notNullValue()));
-    }
-
-    @Test
-    public void shouldWorkMultipleTimes() {
-        System.out.println("Caching Test");
-        // When
-        Forgery forgery = new Forgery.Builder().build();
-
-        // Then
-        assertThat(forgery.forge(Employee.class), is(notNullValue()));
-        assertThat(forgery.forge(Employee.class), is(notNullValue()));
-        assertThat(forgery.forge(Employee.class), is(notNullValue()));
     }
 
     @Test

--- a/src/test/java/uk/co/adaptivelogic/forgery/domain/Employee.java
+++ b/src/test/java/uk/co/adaptivelogic/forgery/domain/Employee.java
@@ -1,6 +1,8 @@
 package uk.co.adaptivelogic.forgery.domain;
 
 import com.google.common.base.Objects;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.util.Date;
 
@@ -45,6 +47,7 @@ public class Employee {
 		this.lastName = lastName;
 	}
 
+	@Override
 	public String toString() {
 		return Objects.toStringHelper(this)
 				.add("firstName", firstName)
@@ -52,5 +55,15 @@ public class Employee {
 				.add("dateOfBirth", dateOfBirth)
 				.add("ssn", ssn)
 				.toString();
+	}
+
+	@Override
+	public boolean equals(Object that) {
+		return EqualsBuilder.reflectionEquals(this, that);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
 	}
 }


### PR DESCRIPTION
I've extracted the builder away from Forgery into a separate class.

So instead of having to do:

```
new Forgery().Builder().build().forge(...
```

you can now just do:

```
import static uk.co.adaptivelogic.forgery.ForgeryBuilder.forgeryBuilder;

forgeryBuilder().build().forge(...
```
